### PR TITLE
Add requests wrappers

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,3 +10,4 @@ python:
       path: .
       extra_requirements:
         - docs
+        - requests

--- a/docs/_static/css/igwnauthutils.css
+++ b/docs/_static/css/igwnauthutils.css
@@ -1,0 +1,30 @@
+/* style sheet for IGWN Auth Utils docs */
+/* Copyright (C) 2021 Cardff University */
+
+/* -- autoclass formatting ------------------------------------------------ */
+
+/* class title */
+dl.class > dt > span,
+dl.function > dt > span {
+		font-size: 120%;
+}
+dl.class > dt > span.descclassname {
+		padding-right: 0;
+}
+dl.class > dt > span.descname {
+		padding-left: 0;
+}
+dl > dt > em > span.n,
+dl > dt > em > span.default_value {
+		font-family: "Roboto mono", "Courier New", Courier, monospace;
+		font-style: normal;
+}
+
+dl.class > dd,
+dl.function > dd {
+		margin-left: 0;
+}
+
+dl.field-list > dt {
+		padding-left: 0;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,11 +56,17 @@ html_theme_options = {
     "master_doc": False,
     "nav_links": [],
 }
+html_static_path = ["_static"]
 
 # -- extensions -------------
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/", None),
+    "requests": ("https://docs.python-requests.org/en/stable/", None),
+    "requests-gracedb": (
+        "https://requests-gracedb.readthedocs.io/en/stable/",
+        None,
+    ),
 }
 
 automodapi_inherited_members = False
@@ -113,3 +119,9 @@ def linkcode_resolve(domain, info):
         top_module.__name__,
         fileref,
     )
+
+
+# -- setup ------------------
+
+def setup(app):
+    app.add_css_file("css/igwnauthutils.css")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,10 +25,20 @@ Documentation
 -------------
 
 .. automodapi:: igwn_auth_utils
-   :no-heading:
    :no-main-docstr:
    :no-inheritance-diagram:
-   :headings: -^
+   :headings: ^"
+
+.. automodapi:: igwn_auth_utils.requests
+   :no-main-docstr:
+   :no-inheritance-diagram:
+   :headings: ^"
+   :skip: netrc
+   :skip: urlparse
+   :skip: IgwnAuthError
+   :skip: find_scitoken
+   :skip: find_x509_credentials
+   :skip: scitoken_authorization_header
 
 -------
 Support

--- a/igwn_auth_utils/requests.py
+++ b/igwn_auth_utils/requests.py
@@ -1,0 +1,361 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Cardiff University
+# Distributed under the terms of the BSD-3-Clause license
+
+"""Python Requests interface with IGWN authentication
+
+This is heavily inspired by Leo Singer's excellent
+:mod:`requests_gracedb` package.
+"""
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+__credits__ = "Leo Singer <leo.singer@ligo.org>"
+
+from urllib.parse import urlparse
+
+from safe_netrc import netrc
+
+import requests
+
+from . import (
+    IgwnAuthError,
+    find_scitoken,
+    find_x509_credentials,
+    scitoken_authorization_header,
+)
+
+_auth_session_parameters = """
+    Discovery/configuration of authorisation/authentication methods
+    is attempted in the following order:
+
+    1.  if ``force_noauth=True`` is given, no auth is configured;
+
+    2.  if a bearer token is provided via the ``token`` keyword argument,
+        then use that;
+
+    3.  if an X.509 credential path is provided via the ``cert`` keyword
+        argument, then use that;
+
+    4.  if ``auth`` keyword is provided, then use that;
+
+    5.  look for a bearer token by passing the ``token_audience``
+        and ``token_scope`` keyword parameters to
+        :func:`igwn_auth_utils.find_scitokens`;
+
+    6.  look for an X.509 credential using
+        :func:`igwn_auth_utils.find_x509_credential`
+
+    7.  read the netrc file located at :file:`~/.netrc`, or at the path
+        stored in the :envvar:`NETRC` environment variable, and look
+        for a username and password matching the hostname given in the
+        ``url`` keyword argument;
+
+    8.  if none of the above yield a credential, and ``fail_if_noauth=True``
+        was provided, raise a `ValueError`.
+
+    Parameters
+    ----------
+    token : `scitokens.SciToken`, `str`, `bool`, optional
+        Bearer token (scitoken) input, one of
+
+        - a bearer token (`scitokens.SciToken`),
+        - a serialised token (`str`, `bytes`),
+        - `False`: disable using tokens completely
+        - `True`: discover a valid token via
+          :func:`igwn_auth_utils.find_scitoken` and
+          error if something goes wrong
+        - `None`: try and discover a valid token, but
+          try something else if that fails
+
+    token_audience, token_scope : `str`
+        The ``audience`` and ``scope`` to pass to
+        :func:`igwn_auth_utils.find_scitoken` when discovering
+        available tokens.
+
+    cert : `str`, `tuple`, `bool`, optional
+        X.509 credential input, one of
+
+        - path to a PEM-format certificate file,
+        - a ``(cert, key)`` `tuple`,
+        - `False`: disable using X.509 completely
+        - `True`: discover a valid cert via
+          :func:`igwn_auth_utils.find_x509_credentials` and
+          error if something goes wrong
+        - `None`: try and discover a valid cert, but
+          try something else if that fails
+
+    auth :  `tuple`, `object`, optional
+        ``(username, password)`` `tuple` or other authentication/authorization
+        object to attach to a `~requests.Request`
+
+    url : `str`, optional
+        the URL that will be queried within this session; this is only
+        used to access credentials via :mod:`safe_netrc`.
+
+    force_noauth : `bool`, optional
+        Disable the use of any authorisation credentials (mainly for testing).
+
+    fail_if_noauth : `bool`, optional
+        Raise a `~igwn_auth_utils.IgwnAuthError` if no authorisation
+        credentials are presented or discovered.
+
+    Raises
+    ------
+    IgwnAuthError
+        If ``cert=True`` or ``token=True`` is given and the relevant
+        credential was not actually discovered, or
+        if ``fail_if_noauth=True`` is given and no authorisation
+        token/credentials of any valid type are presented or discovered.
+
+    Note
+    ----
+    This class requires `Requests <https://requests.readthedocs.io/>`__.
+
+    See also
+    --------
+    requests.Session
+        for details of the standard options
+    """.strip()
+
+
+def _find_cred(func, *args, error=True, **kwargs):
+    """Find a credential and maybe ignore an `~igwn_auth_utils.IgwnAuthError`
+
+    This is an internal utility for the `SessionAuthMixin._init_auth`
+    method which shouldn't necessary fail if it doesn't
+    find a credential of any one type, but should just move on to the
+    next option.
+    """
+    try:
+        return func(*args, **kwargs)
+    except IgwnAuthError:
+        if error:
+            raise
+        return
+
+
+def _hook_raise_for_status(response, *args, **kwargs):
+    """Response hook to raise exception for any HTTP error (status >= 400)
+
+    Reproduced (with permission) from :mod:`requests_gracedb.errors`,
+    authored by Leo Singer.
+    """
+    return response.raise_for_status()
+
+
+class SessionErrorMixin:
+    """A mixin for :class:`requests.Session` to raise exceptions for HTTP
+    errors.
+
+    Reproduced (with permission) from :mod:`requests_gracedb.errors`,
+    authored by Leo Singer.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.hooks.setdefault("response", []).append(
+            _hook_raise_for_status,
+        )
+
+
+class SessionAuthMixin:
+    """Mixin for :class:`requests.Session` to add support for IGWN auth.
+
+    By default this mixin will automatically attempt to discover/configure
+    a bearer token (scitoken) or an X.509 credential, with options to
+    require/disable either of those, or all authentication entirely.
+
+    {parameters}
+    """
+    def __init__(
+        self,
+        token=None,
+        token_audience=None,
+        token_scope=None,
+        cert=None,
+        auth=None,
+        url=None,
+        force_noauth=False,
+        fail_if_noauth=False,
+        **kwargs,
+    ):
+        # initialise session
+        super().__init__(**kwargs)
+
+        # handle options
+        if force_noauth and fail_if_noauth:
+            raise ValueError(
+                "cannot select both force_noauth and fail_if_noauth",
+            )
+        if force_noauth:
+            return
+
+        # find creds if we can
+        _auth = self._init_auth(
+            auth=auth,
+            cert=cert,
+            token=token,
+            token_audience=token_audience,
+            token_scope=token_scope,
+            url=url,
+        )
+
+        # if no auth was found, and we need it, fail here
+        if not _auth and fail_if_noauth:
+            raise IgwnAuthError("no valid authorisation credentials found")
+
+    def _init_auth(
+        self,
+        auth=None,
+        cert=None,
+        token=None,
+        token_audience=None,
+        token_scope=None,
+        url=None,
+    ):
+        # -- user-provided objects
+        # the user gave us something specific, so always use it
+        dummy = (None, False, True)
+        if token not in dummy:
+            return self._set_token_header(token)
+
+        for attr, obj in (
+                ("cert", cert),
+                ("auth", auth),
+        ):
+            if obj not in dummy:
+                setattr(self, attr, obj)
+                return getattr(self, attr)
+
+        # -- the user didn't give us something specific,
+        #    so we go around the houses trying to find something
+        #    we can use
+
+        # bearer token
+        if token is not False:  # not disabled
+            token = self._find_token(
+                token_audience,
+                token_scope,
+                error=bool(token),
+            )
+        if token:
+            return self._set_token_header(token)
+
+        # cert auth
+        if cert is not False:  # not disabled
+            self.cert = self._find_x509_credentials(error=bool(cert))
+        if self.cert:
+            return self.cert
+
+        # basic auth (netrc)
+        if auth is not False:  # not disabled
+            self.auth = self._find_username_password(url)
+
+        return self.auth
+
+    def _set_token_header(self, token):
+        """Serialise a `scitokens.SciToken` and format and store as an
+        Authorization header for this session.
+
+        Parameters
+        ----------
+        token : `scitokens.SciToken`, `str`, `bytes`
+            the token to serialize, or an already serialized representation
+        """
+        if isinstance(token, (str, bytes)):  # load a valid token
+            header = f"Bearer {token}"
+        else:
+            header = scitoken_authorization_header(token)
+        self.headers["Authorization"] = header
+        return header
+
+    @staticmethod
+    def _find_x509_credentials(error=True):
+        """Find an X.509 certificate for authorization
+        """
+        return _find_cred(find_x509_credentials, error=error)
+
+    @staticmethod
+    def _find_token(audience, scope, error=True):
+        """Find a bearer token for authorization
+        """
+        return _find_cred(find_scitoken, audience, scope, error=error)
+
+    @staticmethod
+    def _find_username_password(url):
+        """Use `safe_netrc.netrc` to find the username/password for basic auth
+        """
+        host = urlparse(url).hostname
+
+        try:
+            result = netrc().authenticators(host)
+        except IOError:
+            return
+
+        try:
+            username, _, password = result
+        except TypeError:
+            return
+        return username, password
+
+
+class Session(
+    SessionAuthMixin,
+    SessionErrorMixin,
+    requests.Session,
+):
+    """`requests.Session` class with default IGWN authorization handling
+
+    {parameters}
+
+    Examples
+    --------
+    >>> from igwn_auth_utils.requests import Session
+    >>> with Session(token=mytoken) as sess:
+    ...     sess.get("https://my.science.stuff/data")
+    """
+
+
+# update the docstrings to include the same parameter info
+for _obj in (Session, SessionAuthMixin):
+    _obj.__doc__ = _obj.__doc__.format(parameters=_auth_session_parameters)
+
+
+def get(url, *args, session=None, **kwargs):
+    """Request data from a URL via an HTTP ``'GET'`` request
+
+    Parameters
+    ----------
+    url : `str`,
+        the URL to request
+
+    session : `requests.Session`, optional
+        the connection session to use, if not given one will be
+        created on-the-fly
+
+    *args, **kwargs
+        all other keyword arguments are passed directly to
+        `requests.Session.get`
+
+    Returns
+    -------
+    resp : `requets.Response`
+        the response object
+
+    See also
+    --------
+    requests.Session.get
+        for information on how the request is performed
+    """
+    # user's session
+    if session:
+        return session.get(url, *args, **kwargs)
+
+    # new session
+    sess_kwargs = {k: kwargs.pop(k, None) for k in (
+        "cert",
+        "token",
+        "token_audience",
+        "token_scope",
+    )}
+    with Session(url=url, **sess_kwargs) as session:
+        return session.get(url, *args, **kwargs)

--- a/igwn_auth_utils/tests/test_requests.py
+++ b/igwn_auth_utils/tests/test_requests.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Cardiff University
+# Distributed under the terms of the BSD-3-Clause license
+
+"""Tests for :mod:`igwn_auth_utils.requests`.
+"""
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+__credits__ = "Leo Singer <leo.singer@ligo.org>"
+
+import os
+import stat
+from unittest import mock
+
+import pytest
+
+try:
+    from .. import requests as igwn_requests
+except ModuleNotFoundError as exc:  # pragma: no cover
+    pytest.skip(str(exc), allow_module_level=True)
+else:
+    from requests import RequestException
+from ..error import IgwnAuthError
+from .test_scitokens import rtoken  # noqa: F401
+
+
+def _empty(*args, **kwargs):
+    return []
+
+
+def _igwnerror(*args, **kwargs):
+    raise IgwnAuthError("error")
+
+
+def mock_no_scitoken():
+    return mock.patch(
+        "igwn_auth_utils.scitokens._find_tokens",
+        _empty,
+    )
+
+
+def mock_no_x509():
+    return mock.patch(
+        "igwn_auth_utils.requests.find_x509_credentials",
+        _igwnerror,
+    )
+
+
+@pytest.fixture
+def netrc(tmp_path):
+    netrc = tmp_path / "netrc"
+    netrc.write_text(
+        "machine example.org login albert.einstein password super-secret",
+    )
+    netrc.chmod(stat.S_IRWXU)
+    return netrc
+
+
+def has_auth(session):
+    return bool(
+        session.auth
+        or session.cert
+        or "Authorization" in session.headers
+    )
+
+
+class TestSession:
+    Session = igwn_requests.Session
+
+    # -- SessionErrorMixin
+
+    def test_raise_for_status_hook(self, requests_mock):
+        # define a request that returns 404 (not found)
+        requests_mock.get(
+            "https://test.org",
+            status_code=404,
+            reason="not found",
+        )
+
+        # with the kwarg a RequestException is raised
+        with pytest.raises(RequestException) as exc:
+            igwn_requests.get("https://test.org")
+        assert str(exc.value) == (
+            "404 Client Error: not found for url: https://test.org/"
+        )
+
+    # -- SessionAuthMixin
+
+    def test_noauth_args(self):
+        """Test that `Session(force_noauth=True, fail_if_noauth=True)` is invalid
+        """
+        with pytest.raises(ValueError):
+            self.Session(force_noauth=True, fail_if_noauth=True)
+
+    def test_fail_if_noauth(self):
+        """Test that `Session(fail_if_noauth=True)` raises an error
+        """
+        with pytest.raises(IgwnAuthError):
+            self.Session(
+                token=False,
+                cert=False,
+                url=None,
+                fail_if_noauth=True,
+            )
+
+    def test_force_noauth(self):
+        """Test that `Session(force_noauth=True)` overrides auth kwargs
+        """
+        sess = self.Session(cert="cert.pem", force_noauth=True)
+        assert not has_auth(sess)
+
+    @mock_no_scitoken()
+    @mock_no_x509()
+    def test_defaults(self):
+        """Test that the `Session()` defaults work in a noauth environment
+        """
+        sess = self.Session()
+        assert not has_auth(sess)
+
+    # -- tokens
+
+    def test_token_explicit(self, rtoken):  # noqa: F811
+        """Test that tokens are handled properly
+        """
+        sess = self.Session(token=rtoken)
+        assert sess.headers["Authorization"] == (
+            igwn_requests.scitoken_authorization_header(rtoken)
+        )
+        assert not sess.cert  # only one cred type is stored
+
+    def test_token_serialized(self, rtoken):  # noqa: F811
+        """Test that serialized tokens are handled properly
+        """
+        serialized = rtoken.serialize()
+        sess = self.Session(token=serialized)
+        assert sess.headers["Authorization"] == f"Bearer {serialized}"
+
+    @mock.patch("igwn_auth_utils.requests.find_scitoken")
+    def test_token_discovery(self, find_token, rtoken):  # noqa: F811
+        find_token.return_value = rtoken
+        sess = self.Session()
+        assert sess.headers["Authorization"] == (
+            igwn_requests.scitoken_authorization_header(rtoken)
+        )
+
+    @mock.patch(
+        "igwn_auth_utils.requests.find_scitoken",
+        side_effect=IgwnAuthError,
+    )
+    def test_token_required_failure(self, _):
+        with pytest.raises(IgwnAuthError):
+            self.Session(token=True)
+
+    # -- X.509
+
+    def test_cert_explicit(self):
+        """Test that cert credentials are stored properly
+        """
+        sess = self.Session(token=False, cert="cert.pem")
+        assert sess.cert == "cert.pem"
+        assert has_auth(sess)
+
+    @mock.patch(
+        "igwn_auth_utils.requests.find_x509_credentials",
+        return_value="test.pem",
+    )
+    def test_cert_discovery(self, _):
+        """Test that automatic certificate discovery works
+        """
+        assert self.Session(token=False).cert == "test.pem"
+
+    @mock.patch(
+        "igwn_auth_utils.requests.find_x509_credentials",
+        side_effect=IgwnAuthError,
+    )
+    def test_cert_required_failure(self, _):
+        with pytest.raises(IgwnAuthError):
+            self.Session(token=False, cert=True)
+
+    # -- basic auth
+
+    @mock.patch.dict(os.environ)
+    @pytest.mark.parametrize(("url", "auth"), (
+        ("https://example.org", ("albert.einstein", "super-secret")),
+        ("https://bad.org", None),
+    ))
+    def test_basic_auth(self, netrc, url, auth):
+        os.environ["NETRC"] = str(netrc)
+        sess = self.Session(cert=False, token=False, url=url)
+        assert sess.auth == auth
+
+
+def test_get(requests_mock):
+    """Test that `igwn_auth_utils.requests.get` can perform a simple request
+    """
+    requests_mock.get(
+        "https://test.org",
+        text="TEST",
+    )
+    assert igwn_requests.get("https://test.org").text == "TEST"
+
+
+@mock.patch("igwn_auth_utils.requests.Session")
+def test_get_session(mock_session):
+    """Test that ``session`` for `igwn_auth_utils.requests.get` works
+    """
+    session = mock.MagicMock()
+    assert igwn_requests.get("https://test.org", session=session)
+    session.get.assert_called_once_with("https://test.org")
+    mock_session.assert_not_called()

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,9 +47,15 @@ docs =
 	sphinx >= 4.0.0
 	sphinx-automodapi
 	sphinx-material
+requests =
+	requests
+	safe-netrc
 test =
 	pytest >= 3.9.1
 	pytest-cov
+	requests
+	requests-mock
+	safe-netrc
 
 # -- tools ------------------
 


### PR DESCRIPTION
This PR introduces `igwn_auth_utils.requests`, which provides an IGWN auth mixin class for `requests.Session` to simplify use of the auth discovery methods in that context.

This is heavily influenced by `requests-gracedb` so @lpsinger should be involved in any discussion on reducing the overlap between that project and this one to provide a single `requests` wrapper for X.509/scitokens clients.