### PR TITLE
Update to scitokens 1.5.0

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -57,6 +57,7 @@ jobs:
       matrix:
         debian:
           - buster
+          - bullseye
     runs-on: ubuntu-latest
     container: igwn/base:${{ matrix.debian }}
     env:
@@ -120,6 +121,7 @@ jobs:
       matrix:
         debian:
           - buster
+          - bullseye
     runs-on: ubuntu-latest
     container: igwn/base:${{ matrix.debian }}
     env:
@@ -185,6 +187,7 @@ jobs:
       matrix:
         debian:
           - buster
+          - bullseye
     runs-on: ubuntu-latest
     container: igwn/base:${{ matrix.debian }}
     steps:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -209,15 +209,21 @@ jobs:
 
   lint-debian:
     name: Lint Debian packages
-    runs-on: ubuntu-latest
-    container: debian
     needs:
       - debian-binary
+    strategy:
+      fail-fast: false
+      matrix:
+        debian:
+          - buster
+          - bullseye
+    runs-on: ubuntu-latest
+    container: debian:${{ matrix.debian }}
     steps:
       - name: Download debian package
         uses: actions/download-artifact@v2
         with:
-          name: deb-buster
+          name: deb-${{ matrix.debian }}
 
       - name: Install lintian
         run: |
@@ -227,6 +233,11 @@ jobs:
           ;
 
       - name: Lintian
+        if: matrix.debian == 'buster'
+        run: lintian --color=auto --fail-on-warnings --allow-root --pedantic --suppress-tags manpage-has-useless-whatis-entry,manpage-has-errors-from-man *.changes
+
+      - name: Lintian
+        if: matrix.debian == 'bullseye'
         run: lintian --color=auto --fail-on warning --allow-root --pedantic --suppress-tags manpage-has-useless-whatis-entry,manpage-has-errors-from-man *.changes
 
   # -- RHEL -----------------
@@ -394,15 +405,21 @@ jobs:
 
   lint-rhel:
     name: Lint RPMs
-    runs-on: ubuntu-latest
-    container: centos:8
     needs:
       - rhel-binary
+    strategy:
+      fail-fast: false
+      matrix:
+        el:
+          - 7
+          - 8
+    runs-on: ubuntu-latest
+    container: centos:8
     steps:
       - name: Download RPM
         uses: actions/download-artifact@v2
         with:
-          name: rpm-el8-testing
+          name: rpm-el${{ matrix.el }}-testing
 
       - name: Install rpmlint
         run: |
@@ -415,8 +432,6 @@ jobs:
           cat << EOF > rpmlintrc
           # don't validate Source0
           setOption("NetworkEnabled", False)
-          # the regex rpmlint uses to identify 'lib' libraries is crap
-          addFilter('explicit-lib-dependency (.*)?matplotlib')
           EOF
 
       - name: Lint

--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,7 @@ Depends:
  ${misc:Depends},
  ${python3:Depends},
  python3-cryptography,
- python3-scitokens,
+ python3-scitokens (>= 1.5.0),
 Description: Authorisation utilities for IGWN
  Python library functions to simplify using IGWN authorisation credentials.
  This project is primarily aimed at discovering X.509 credentials and

--- a/igwn-auth-utils.spec
+++ b/igwn-auth-utils.spec
@@ -30,7 +30,7 @@ BuildRequires: python%{python3_pkgversion}-wheel
 # test dependencies
 BuildRequires: python%{python3_pkgversion}-cryptography
 BuildRequires: python%{python3_pkgversion}-pip
-BuildRequires: python3-scitokens
+BuildRequires: python%{python3_pkgversion}-scitokens >= 1.5.0
 
 %description
 Python library functions to simplify using IGWN authorisation credentials.
@@ -41,7 +41,7 @@ SciTokens for use with HTTP(S) requests to IGWN-operated services.
 
 %package -n python%{python3_pkgversion}-%{name}
 Requires: python%{python3_pkgversion}-cryptography
-Requires: python3-scitokens
+Requires: python%{python3_pkgversion}-scitokens >= 1.5.0
 Summary:  %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
 %description -n python%{python3_pkgversion}-%{name}

--- a/igwn_auth_utils/scitokens.py
+++ b/igwn_auth_utils/scitokens.py
@@ -158,18 +158,7 @@ def _find_tokens(**deserialize_kwargs):
     attempting to parse a token that was actually found, so that
     they can be handled by the caller.
     """
-    try:
-        from scitokens.utils.errors import SciTokensException
-    except ImportError:  # scitokens < 1.4.1
-        from scitokens.utils import errors as _scitokens_errors
-        SciTokensException = (
-            _scitokens_errors.InvalidTokenFormat,
-            _scitokens_errors.MissingIssuerException,
-            _scitokens_errors.MissingKeyException,
-            _scitokens_errors.NonHTTPSIssuer,
-            _scitokens_errors.UnableToCreateCache,
-            _scitokens_errors.UnsupportedKeyException,
-        )
+    from scitokens.utils.errors import SciTokensException
 
     def _token_or_exception(func, *args, **kwargs):
         try:

--- a/igwn_auth_utils/tests/test_scitokens.py
+++ b/igwn_auth_utils/tests/test_scitokens.py
@@ -13,10 +13,6 @@ from unittest import mock
 
 from scitokens import SciToken
 from scitokens.utils.errors import NonHTTPSIssuer
-try:
-    from scitokens import __version__ as scitokens_version
-except ImportError:
-    scitokens_version = "0.0.0"
 
 import pytest
 
@@ -273,11 +269,6 @@ def test_find_condor_creds_dir_empty(tmp_path):
     assert not list(igwn_scitokens._find_condor_creds_token_paths())
 
 
-@pytest.mark.xfail(
-    scitokens_version < "1.4.1",
-    reason="bug in scitokens",
-    strict=True,
-)
 def test_token_authorization_header(rtoken):
     """Check that `token_authorization_header` works
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ setup_requires =
 	wheel
 install_requires =
 	cryptography
-	scitokens
+	scitokens >= 1.5.0
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
This PR updates the scitokens requirement to 1.5.0, which allows removing some hacky workarounds.