### PR TITLE
Add new error module to provide IgwnAuthError

### DIFF
--- a/igwn_auth_utils/__init__.py
+++ b/igwn_auth_utils/__init__.py
@@ -6,6 +6,7 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __credits__ = "Duncan Brown, Leo Singer"
 __license__ = "BSD-3-Clause"
 
+from .error import IgwnAuthError
 from .scitokens import (
     find_token as find_scitoken,
     token_authorization_header as scitoken_authorization_header,

--- a/igwn_auth_utils/error.py
+++ b/igwn_auth_utils/error.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Cardiff University
+# Distributed under the terms of the BSD-3-Clause license
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+
+class IgwnAuthError(RuntimeError):
+    """Error in discovering/validating an IGWN auth credential.
+    """

--- a/igwn_auth_utils/scitokens.py
+++ b/igwn_auth_utils/scitokens.py
@@ -10,6 +10,7 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 import os
 from pathlib import Path
 
+from .error import IgwnAuthError
 from scitokens import (
     Enforcer,
     SciToken,
@@ -123,7 +124,7 @@ def find_token(audience, scope, timeleft=600, skip_errors=False, **kwargs):
 
     Raises
     ------
-    RuntimeError
+    ~igwn_auth_utils.IgwnAuthError
         if no valid token can be found
 
     See also
@@ -144,7 +145,7 @@ def find_token(audience, scope, timeleft=600, skip_errors=False, **kwargs):
             return token
 
     # if we didn't find any valid tokens:
-    raise RuntimeError(
+    raise IgwnAuthError(
         "could not find a valid SciToken, "
         "please verify the audience and scope, "
         "or generate a new token and try again",

--- a/igwn_auth_utils/tests/test_scitokens.py
+++ b/igwn_auth_utils/tests/test_scitokens.py
@@ -17,6 +17,7 @@ from scitokens.utils.errors import NonHTTPSIssuer
 import pytest
 
 from .. import scitokens as igwn_scitokens
+from ..error import IgwnAuthError
 
 ISSUER = "local"
 AUDIENCE = "igwn_auth_utils"
@@ -207,7 +208,7 @@ def test_find_token_error(rtoken, public_pem):
     # token with the wrong claims
     os.environ["SCITOKEN"] = rtoken.serialize().decode("utf-8")
     # check that we get an error
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(IgwnAuthError) as exc:
         igwn_scitokens.find_token(
             AUDIENCE,
             WRITE_SCOPE,
@@ -222,7 +223,7 @@ def test_find_token_error(rtoken, public_pem):
 @mock.patch.dict("os.environ")
 @pytest.mark.parametrize(("skip_errors", "error_type", "message"), (
     (False, NonHTTPSIssuer, "Issuer is not over HTTPS"),
-    (True, RuntimeError, "could not find a valid SciToken"),
+    (True, IgwnAuthError, "could not find a valid SciToken"),
 ))
 def test_find_token_skip_errors(rtoken, skip_errors, error_type, message):
     """Check that the ``skip_errors`` keyword for `find_token()` works

--- a/igwn_auth_utils/tests/test_x509.py
+++ b/igwn_auth_utils/tests/test_x509.py
@@ -25,6 +25,7 @@ from cryptography.hazmat.primitives import (
 import pytest
 
 from .. import x509 as igwn_x509
+from ..error import IgwnAuthError
 
 
 # -- fixtures ---------------
@@ -175,7 +176,7 @@ def test_find_credentials_error(_):
         os.environ.pop(f"X509_USER_{suffix}", None)
 
     # check that we can't find any credentials
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(IgwnAuthError) as exc:
         igwn_x509.find_credentials()
     assert str(exc.value).startswith(
         "could not find an RFC-3820 compliant X.509 credential",

--- a/igwn_auth_utils/x509.py
+++ b/igwn_auth_utils/x509.py
@@ -12,6 +12,8 @@ from cryptography.x509 import (
 )
 from cryptography.hazmat.backends import default_backend
 
+from .error import IgwnAuthError
+
 
 def load_x509_certificate_file(file, backend=None):
     """Load a PEM-format X.509 certificate from a file, or file path
@@ -155,7 +157,7 @@ def find_credentials(timeleft=600):
 
     Raises
     ------
-    RuntimeError
+    ~igwn_auth_utils.IgwnAuthError
         if not certificate files can be found, or if the files found on
         disk cannot be validtted.
 
@@ -204,7 +206,7 @@ def find_credentials(timeleft=600):
         ):
             return cert, key
 
-    raise RuntimeError(
+    raise IgwnAuthError(
         "could not find an RFC-3820 compliant X.509 credential, "
         "please generate one and try again.",
     )


### PR DESCRIPTION
As suggested in https://github.com/duncanmmacleod/igwn-auth-utils/pull/5#discussion_r758448588, this PR adds a new `igwn_auth_utils.error` module to provide the `IgwnAuthError` class as a subclass of `RuntimeError`, to allow callers to catch only our authentication errors.