### PR TITLE
Finalise release: 0.2.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+igwn-auth-utils (0.2.0-1) unstable; urgency=low
+
+  * update to 0.2.0
+
+ -- Duncan Macleod <duncan.macleod@ligo.org>  Mon, 20 Dec 2021 16:32:29 +0000
+
 igwn-auth-utils (0.1.0-1) unstable; urgency=low
 
   * initial release

--- a/igwn-auth-utils.spec
+++ b/igwn-auth-utils.spec
@@ -1,5 +1,5 @@
 %define name    igwn-auth-utils
-%define version 0.1.0
+%define version 0.2.0
 %define release 1
 
 Name:      %{name}
@@ -76,5 +76,8 @@ rm -rf $RPM_BUILD_ROOT
 # -- changelog
 
 %changelog
+* Mon Dec 20 2021 Duncan Macleod <duncan.macleod@ligo.org> - 0.2.0-1
+- update to 0.2.0
+
 * Thu Oct 7 2021 Duncan Macleod <duncan.macleod@ligo.org> - 0.1.0-1
 - initial release


### PR DESCRIPTION
This PR updates the packaging to finalise the [0.2.0](https://github.com/duncanmmacleod/igwn-auth-utils/milestone/3) release.