### PR TITLE
Add packaging references to requests and safe-netrc

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,9 @@ Depends:
  ${python3:Depends},
  python3-cryptography,
  python3-scitokens (>= 1.5.0),
+Recommends:
+ python3-netrc,
+ python3-requests,
 Description: Authorisation utilities for IGWN
  Python library functions to simplify using IGWN authorisation credentials.
  This project is primarily aimed at discovering X.509 credentials and

--- a/igwn-auth-utils.spec
+++ b/igwn-auth-utils.spec
@@ -42,6 +42,10 @@ SciTokens for use with HTTP(S) requests to IGWN-operated services.
 %package -n python%{python3_pkgversion}-%{name}
 Requires: python%{python3_pkgversion}-cryptography
 Requires: python%{python3_pkgversion}-scitokens >= 1.5.0
+%if 0%{?rhel} == 0 || 0%{?rhel} >= 8
+Recommends: python%{python3_pkgversion}-requests
+Recommends: python%{python3_pkgversion}-safe-netrc
+%endif
 Summary:  %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
 %description -n python%{python3_pkgversion}-%{name}


### PR DESCRIPTION
This PR adds 'Recommends' entries in the RHEL/Debian files for `requests` and `safe-netrc` to tell the user that these are strongly recommended for the best experience.