### PR TITLE
Improve SciToken Enforcer argument handling

### DIFF
--- a/igwn_auth_utils/scitokens.py
+++ b/igwn_auth_utils/scitokens.py
@@ -24,13 +24,24 @@ WINDOWS = os.name == "nt"
 def is_valid_token(token, audience, scope, timeleft=600):
     enforcer = Enforcer(token["iss"], audience=audience)
 
+    # add validator for timeleft
     def _validate_timeleft(value):
         exp = float(value)
         return exp >= enforcer._now + timeleft
 
     enforcer.add_validator("exp", _validate_timeleft)
-    scheme, path = scope.split(":", 1)
-    return enforcer.test(token, scheme, path)
+
+    # parse scope as scheme:path
+    authz = None
+    path = None
+    if scope is not None:
+        try:
+            authz, path = scope.split(":", 1)
+        except ValueError:
+            authz = scope
+
+    # test
+    return enforcer.test(token, authz, path=path)
 
 
 # -- I/O --------------------

--- a/igwn_auth_utils/tests/test_scitokens.py
+++ b/igwn_auth_utils/tests/test_scitokens.py
@@ -115,8 +115,9 @@ def _assert_claims_equal(a, b):
 # -- tests --------------------------------------
 
 @pytest.mark.parametrize(("scope", "validity"), (
-    (READ_SCOPE, True),
-    (WRITE_SCOPE, False),
+    (READ_SCOPE, True),  # read scope matches token
+    (WRITE_SCOPE, False),  # write scope doesn't
+    (None, False),  # token has scope, so one is enforced
 ))
 def test_is_valid_token(rtoken, scope, validity):
     assert igwn_scitokens.is_valid_token(rtoken, AUDIENCE, scope) is validity


### PR DESCRIPTION
This PR improves the way that `scitokens.Enforcer` is used to valid a bearer token.