### PR TITLE
Fix image for rpmlint job

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -414,7 +414,7 @@ jobs:
           - 7
           - 8
     runs-on: ubuntu-latest
-    container: centos:8
+    container: rockylinux:8
     steps:
       - name: Download RPM
         uses: actions/download-artifact@v2


### PR DESCRIPTION
This PR fixes the image used for the `rpmlint` CI jobs, `centos:8` is dead, long live `rockylinux:8`